### PR TITLE
Notification task bleed test

### DIFF
--- a/src/ggrc/notification/__init__.py
+++ b/src/ggrc/notification/__init__.py
@@ -48,10 +48,6 @@ def get_notification_data(notifications):
     return {}
   aggregate_data = {}
 
-  def merge_into(destination, source):
-    if destination is None:
-      return source
-
   for pn in notifications:
     data = services.call_service(pn.object_type.name, pn)
     aggregate_data = merge_dict(aggregate_data, data)

--- a/src/ggrc/notification/__init__.py
+++ b/src/ggrc/notification/__init__.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from freezegun import freeze_time
 from datetime import date, datetime
 from ggrc.extensions import get_extension_modules
-from ggrc.models import Notification
+from ggrc.models import Notification, NotificationConfig
 from ggrc.utils import merge_dict
 from ggrc import db
 from sqlalchemy import and_
@@ -35,12 +35,23 @@ class NotificationServices():
       raise ValueError("unknown service name: %s" % name)
     return self.services[name]
 
-  def call_service(self, name, pn):
+  def call_service(self, name, notification):
     service = self.get_service_function(name)
-    return service(pn)
+    return service(notification)
 
 
 services = NotificationServices()
+
+
+def get_filter_data(notification):
+  result = {}
+  data = services.call_service(notification.object_type.name, notification)
+  for user, user_data in data.iteritems():
+    if should_receive(notification,
+                      user_data["force_notifications"],
+                      user_data["user"]["id"]):
+      result[user] = user_data
+  return result
 
 
 def get_notification_data(notifications):
@@ -48,9 +59,9 @@ def get_notification_data(notifications):
     return {}
   aggregate_data = {}
 
-  for pn in notifications:
-    data = services.call_service(pn.object_type.name, pn)
-    aggregate_data = merge_dict(aggregate_data, data)
+  for notification in notifications:
+    filtered_data = get_filter_data(notification)
+    aggregate_data = merge_dict(aggregate_data, filtered_data)
 
   return aggregate_data
 
@@ -88,3 +99,50 @@ def generate_notification_email(data):
 
 def dispatch_notifications():
   pass
+
+
+def should_receive(notif, force_notif, person_id, nightly_cron=True):
+  """
+  nigtly_cron - There are two types of cron jobs, nightly for email digest
+  and a 5 minute cron job for instant notifications. This field is true if
+  the current notification will be sent as part of the digest email, and false
+  otherwise.
+
+  send_on - In digest notifications this field is always set to a certain date.
+  In instant notifications it can be set to today, or NULL. If the field is
+  set, then the instant notification should be sent as part of the digest email
+  for users who don't have instant notificaitons enabled. If the field is not
+  set, the notification will be sent to users with instant notifications with
+  the 5 minute cron job.
+  """
+  def is_enabled(notif_type):
+    return NotificationConfig.query.filter(
+        and_(NotificationConfig.person_id == person_id,
+             NotificationConfig.enable_flag == True,  # noqa
+             NotificationConfig.notif_type == notif_type)).count() > 0
+
+  has_instant = force_notif or is_enabled("Email_Now")
+  has_digest = has_instant or is_enabled("Email_Digest")
+
+  return has_digest
+
+  # To be used when instant notifications are enabled
+  # if not nightly_cron and\
+  #         has_instant and\
+  #         notif.notification_type.instant and\
+  #         not notif.send_on:
+  #   return True
+
+  # if nightly_cron and\
+  #         not has_instant and\
+  #         has_digest and\
+  #         notif.notification_type.instant and\
+  #         notif.send_on:
+  #   return True
+
+  # if nightly_cron and\
+  #         not notif.notification_type.instant and\
+  #         has_digest:
+  #   return True
+
+  # return False

--- a/src/ggrc/notification/__init__.py
+++ b/src/ggrc/notification/__init__.py
@@ -48,7 +48,7 @@ def get_filter_data(notification):
   data = services.call_service(notification.object_type.name, notification)
   for user, user_data in data.iteritems():
     if should_receive(notification,
-                      user_data["force_notifications"],
+                      user_data["force_notifications"][notification.id],
                       user_data["user"]["id"]):
       result[user] = user_data
   return result

--- a/src/ggrc/notification/__init__.py
+++ b/src/ggrc/notification/__init__.py
@@ -102,19 +102,6 @@ def dispatch_notifications():
 
 
 def should_receive(notif, force_notif, person_id, nightly_cron=True):
-  """
-  nigtly_cron - There are two types of cron jobs, nightly for email digest
-  and a 5 minute cron job for instant notifications. This field is true if
-  the current notification will be sent as part of the digest email, and false
-  otherwise.
-
-  send_on - In digest notifications this field is always set to a certain date.
-  In instant notifications it can be set to today, or NULL. If the field is
-  set, then the instant notification should be sent as part of the digest email
-  for users who don't have instant notificaitons enabled. If the field is not
-  set, the notification will be sent to users with instant notifications with
-  the 5 minute cron job.
-  """
   def is_enabled(notif_type):
     return NotificationConfig.query.filter(
         and_(NotificationConfig.person_id == person_id,
@@ -125,24 +112,3 @@ def should_receive(notif, force_notif, person_id, nightly_cron=True):
   has_digest = has_instant or is_enabled("Email_Digest")
 
   return has_digest
-
-  # To be used when instant notifications are enabled
-  # if not nightly_cron and\
-  #         has_instant and\
-  #         notif.notification_type.instant and\
-  #         not notif.send_on:
-  #   return True
-
-  # if nightly_cron and\
-  #         not has_instant and\
-  #         has_digest and\
-  #         notif.notification_type.instant and\
-  #         notif.send_on:
-  #   return True
-
-  # if nightly_cron and\
-  #         not notif.notification_type.instant and\
-  #         has_digest:
-  #   return True
-
-  # return False

--- a/src/ggrc_workflows/notification/__init__.py
+++ b/src/ggrc_workflows/notification/__init__.py
@@ -63,6 +63,9 @@ All notifications handle the following structure:
       "some@email.com": {
           "user": { user_info },
 
+          # if notifications are forced for the given workflow
+          "force_notifications": True/False
+
           "cycle_starts_in": {
               workflow.id: {
                   "custom_message": ""

--- a/src/ggrc_workflows/notification/__init__.py
+++ b/src/ggrc_workflows/notification/__init__.py
@@ -64,7 +64,9 @@ All notifications handle the following structure:
           "user": { user_info },
 
           # if notifications are forced for the given workflow
-          "force_notifications": True/False
+          "force_notifications": {
+              notification.id :True/False
+          }
 
           "cycle_starts_in": {
               workflow.id: {

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -15,6 +15,7 @@ from ggrc_workflows.models import (
 from ggrc_basic_permissions.models import Role, UserRole
 from ggrc import db
 from ggrc.utils import merge_dicts
+from ggrc.models import NotificationConfig
 
 
 """
@@ -358,3 +359,62 @@ def get_workflow_url(workflow):
       base=request.url_root,
       workflow_id=workflow.id,
   )
+
+
+def should_recieve(notif, workflow, person, nightly_cron=True):
+  """
+  nigtly_cron - There are two types of cron jobs, nightly for email digest
+  and a 5 minute cron job for instant notifications. This field is true if
+  the current notification will be sent as part of the digest email, and false
+  otherwise.
+
+  send_on - In digest notifications this field is always set to a certain date.
+  In instant notifications it can be set to today, or NULL. If the field is
+  set, then the instant notification should be sent as part of the digest email
+  for users who don't have instant notificaitons enabled. If the field is not
+  set, the notification will be sent to users with instant notifications with
+  the 5 minute cron job.
+
+  """
+  def is_enabled(notif_type):
+    return NotificationConfig.query.filter(
+        and_(NotificationConfig.person_id == person.id,
+             NotificationConfig.enable_flag == True,  # noqa
+             NotificationConfig.notif_type == notif_type)).count() > 0
+
+  has_instant = is_enabled("Email_Now") or workflow.notify_on_change
+  has_digest = is_enabled("Email_Digest") or has_instant
+
+  if not nightly_cron and\
+          has_instant and\
+          notif.notification_type.instant and\
+          not notif.send_on:
+    return True
+
+  if nightly_cron and\
+          not has_instant and\
+          has_digest and\
+          notif.notification_type.instant and\
+          notif.send_on:
+    return True
+
+  if nightly_cron and\
+          not notif.notification_type.instant and\
+          has_digest:
+    return True
+
+  return False
+
+  # This if statetemt is equivalent to the tree statements above but
+  # harder to read
+  # if nightly_cron:
+  #   if notif.notification_type.instant:
+  #     return notif.send_on and\
+  #       person_digest and\
+  #       not has_instant
+  #   else:
+  #     return person_digest
+  # else:
+  #   return notif.notification_type.instant and\
+  #     not notif.send_on and\
+  #     has_instant

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -15,7 +15,6 @@ from ggrc_workflows.models import (
 from ggrc_basic_permissions.models import Role, UserRole
 from ggrc import db
 from ggrc.utils import merge_dicts
-from ggrc.models import NotificationConfig
 
 
 """
@@ -49,7 +48,9 @@ def get_cycle_created_task_data(notification):
   assignee_data = {
       task_assignee['email']: {
           "user": task_assignee,
-          "force_notifications": force,
+          "force_notifications": {
+            notification.id: force
+          },
           "cycle_started": {
               cycle.id: {
                   "my_tasks": task
@@ -60,7 +61,9 @@ def get_cycle_created_task_data(notification):
   tg_assignee_data = {
       task_group_assignee['email']: {
           "user": task_group_assignee,
-          "force_notifications": force,
+          "force_notifications": {
+            notification.id: force
+          },
           "cycle_started": {
               cycle.id: {
                   "my_task_groups": {
@@ -74,7 +77,9 @@ def get_cycle_created_task_data(notification):
     wf_owner_data = {
         workflow_owner['email']: {
             "user": workflow_owner,
-            "force_notifications": force,
+            "force_notifications": {
+              notification.id: force
+            },
             "cycle_started": {
                 cycle.id: {
                     "cycle_tasks": task
@@ -97,7 +102,9 @@ def get_cycle_task_due(notification):
   return {
       cycle_task.contact.email: {
           "user": get_person_dict(cycle_task.contact),
-          "force_notifications": force,
+          "force_notifications": {
+            notification.id: force
+          },
           due: {
               cycle_task.id: get_cycle_task_dict(cycle_task)
           }
@@ -113,7 +120,9 @@ def get_all_cycle_tasks_completed_data(notification, cycle):
     wf_data = {
         workflow_owner['email']: {
             "user": workflow_owner,
-            "force_notifications": force,
+            "force_notifications": {
+              notification.id: force
+            },
             "all_tasks_completed": {
                 cycle.id: get_cycle_dict(cycle)
             }
@@ -134,7 +143,9 @@ def get_cycle_created_data(notification, cycle):
   for person in cycle.workflow.people:
     result[person.email] = {
         "user": get_person_dict(person),
-        "force_notifications": force,
+        "force_notifications": {
+          notification.id: force
+        },
         "cycle_started": {
             cycle.id: get_cycle_dict(cycle, manual)
         }
@@ -165,7 +176,9 @@ def get_cycle_task_declined_data(notification):
   return {
       cycle_task.contact.email: {
           "user": get_person_dict(cycle_task.contact),
-          "force_notifications": force,
+          "force_notifications": {
+            notification.id: force
+          },
           "task_declined": {
               cycle_task.id: get_cycle_task_dict(cycle_task)
           }
@@ -216,7 +229,9 @@ def get_task_group_task_data(notification):
   assignee_data = {
       task_assignee['email']: {
           "user": task_assignee,
-          "force_notifications": force,
+          "force_notifications": {
+            notification.id: force
+          },
           "cycle_starts_in": {
               workflow.id: {
                   "my_tasks": tasks
@@ -227,7 +242,9 @@ def get_task_group_task_data(notification):
   tg_assignee_data = {
       task_group_assignee['email']: {
           "user": task_group_assignee,
-          "force_notifications": force,
+          "force_notifications": {
+            notification.id: force
+          },
           "cycle_starts_in": {
               workflow.id: {
                   "my_task_groups": {
@@ -241,7 +258,9 @@ def get_task_group_task_data(notification):
     wf_owner_data = {
         workflow_owner['email']: {
             "user": workflow_owner,
-            "force_notifications": force,
+            "force_notifications": {
+              notification.id: force
+            },
             "cycle_starts_in": {
                 workflow.id: {
                     "workflow_tasks": tasks
@@ -272,7 +291,9 @@ def get_workflow_data(notification):
   for wf_person in workflow.workflow_people:
     result[wf_person.person.email] = {
         "user": get_person_dict(wf_person.person),
-        "force_notifications": force,
+        "force_notifications": {
+          notification.id: force
+        },
         "cycle_starts_in": {
             workflow.id: {
                 "workflow_owners": workflow_owners,

--- a/src/ggrc_workflows/notification/notification_handler.py
+++ b/src/ggrc_workflows/notification/notification_handler.py
@@ -206,19 +206,3 @@ def add_notif(obj, notif_type, send_on=None):
       send_on=send_on,
   )
   db.session.add(notif)
-
-
-def is_instant(workflow, person):
-  def is_enabled(notif_type):
-    return NotificationConfig.query.filter(
-        and_(NotificationConfig.person_id == person.id,
-             NotificationConfig.enable_flag == True,  # noqa
-             NotificationConfig.notif_type == notif_type)).count() > 0
-
-  if workflow.notify_on_change and is_enabled("Email_Now"):
-    return "instant"
-
-  if is_enabled("Email_Digest"):
-    return "digest"
-
-  return None

--- a/src/tests/ggrc_workflows/notifications/test_deleted_objects.py
+++ b/src/tests/ggrc_workflows/notifications/test_deleted_objects.py
@@ -88,6 +88,7 @@ class TestNotificationsForDeletedObjects(TestCase):
 
     self.quarterly_wf_1 = {
         "title": "quarterly wf 1",
+        "notify_on_change": True,
         "description": "",
         "owners": [person_dict(self.user.id)],
         "frequency": "quarterly",

--- a/src/tests/ggrc_workflows/notifications/test_enable_disable_notifications.py
+++ b/src/tests/ggrc_workflows/notifications/test_enable_disable_notifications.py
@@ -1,0 +1,179 @@
+# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+import random
+from tests.ggrc import TestCase
+from freezegun import freeze_time
+from datetime import datetime
+from mock import patch
+
+import os
+from ggrc import notification
+from ggrc.models import NotificationConfig, Notification, Person
+from tests.ggrc_workflows.generator import WorkflowsGenerator
+from tests.ggrc.api_helper import Api
+from tests.ggrc.generator import GgrcGenerator
+
+
+if os.environ.get('TRAVIS', False):
+  random.seed(1)  # so we can reproduce the tests if needed
+
+
+class TestEnableAndDisableNotifications(TestCase):
+
+  """ This class contains simple one time workflow tests that are not
+  in the gsheet test grid
+  """
+
+  def setUp(self):
+    TestCase.setUp(self)
+    self.api = Api()
+    self.wf_generator = WorkflowsGenerator()
+    self.ggrc_generator = GgrcGenerator()
+    Notification.query.delete()
+
+    self.random_objects = self.ggrc_generator.generate_random_objects(2)
+    _, self.user = self.ggrc_generator.generate_person(user_role="gGRC Admin")
+    self.create_test_cases()
+
+    def init_decorator(init):
+      def new_init(self, *args, **kwargs):
+        init(self, *args, **kwargs)
+        if hasattr(self, "created_at"):
+          self.created_at = datetime.now()
+      return new_init
+
+    Notification.__init__ = init_decorator(Notification.__init__)
+
+  @patch("ggrc.notification.email.send_email")
+  def test_disabled_notifications(self, mock_mail):
+
+    with freeze_time("2015-02-01 13:39:20"):
+      _, wf = self.wf_generator.generate_workflow(self.quarterly_wf)
+      response, wf = self.wf_generator.activate_workflow(wf)
+
+      self.assert200(response)
+
+      user = Person.query.get(self.user.id)
+
+    with freeze_time("2015-01-01 13:39:20"):
+      _, notif_data = notification.get_todays_notifications()
+      self.assertNotIn(user.email, notif_data)
+
+    with freeze_time("2015-01-29 13:39:20"):
+      _, notif_data = notification.get_todays_notifications()
+      self.assertNotIn(user.email, notif_data)
+
+  @patch("ggrc.notification.email.send_email")
+  def test_enabled_notifications(self, mock_mail):
+
+    with freeze_time("2015-02-01 13:39:20"):
+      _, wf = self.wf_generator.generate_workflow(self.quarterly_wf)
+      response, wf = self.wf_generator.activate_workflow(wf)
+
+      self.assert200(response)
+
+      user = Person.query.get(self.user.id)
+
+    with freeze_time("2015-01-29 13:39:20"):
+      _, notif_data = notification.get_todays_notifications()
+      self.assertNotIn(user.email, notif_data)
+
+
+      data = {
+          "notification_config": {
+              "person_id": user.id,
+              "notif_type": "Email_Digest",
+              "enable_flag": True,
+              "context": None,
+              "type": "NotificationConfig",
+          }
+      }
+      response = self.ggrc_generator.api.post(NotificationConfig, data)
+
+      user = Person.query.get(self.user.id)
+      _, notif_data = notification.get_todays_notifications()
+      self.assertIn(user.email, notif_data)
+
+  @patch("ggrc.notification.email.send_email")
+  def test_forced_notifications(self, mock_mail):
+
+    with freeze_time("2015-02-01 13:39:20"):
+      _, wf = self.wf_generator.generate_workflow(self.quarterly_wf_forced)
+      response, wf = self.wf_generator.activate_workflow(wf)
+
+      self.assert200(response)
+
+      user = Person.query.get(self.user.id)
+
+    with freeze_time("2015-01-29 13:39:20"):
+      _, notif_data = notification.get_todays_notifications()
+      self.assertIn(user.email, notif_data)
+
+      data = {
+          "notification_config": {
+              "person_id": user.id,
+              "notif_type": "Email_Digest",
+              "enable_flag": True,
+              "context": None,
+              "type": "NotificationConfig",
+          }
+      }
+      response = self.ggrc_generator.api.post(NotificationConfig, data)
+
+      user = Person.query.get(self.user.id)
+      _, notif_data = notification.get_todays_notifications()
+      self.assertIn(user.email, notif_data)
+
+  def create_test_cases(self):
+    def person_dict(person_id):
+      return {
+          "href": "/api/people/%d" % person_id,
+          "id": person_id,
+          "type": "Person"
+      }
+
+    self.quarterly_wf_forced = {
+        "title": "quarterly wf forced notification",
+        "notify_on_change": True,
+        "description": "",
+        "owners": [person_dict(self.user.id)],
+        "frequency": "quarterly",
+        "task_groups": [{
+            "title": "tg_1",
+            "contact": person_dict(self.user.id),
+            "task_group_tasks": [{
+                "contact": person_dict(self.user.id),
+                "description": self.wf_generator.random_str(100),
+                "relative_start_day": 5,
+                "relative_start_month": 2,
+                "relative_end_day": 25,
+                "relative_end_month": 2,
+            },
+            ],
+        },
+        ]
+    }
+
+    self.quarterly_wf = {
+        "title": "quarterly wf 1",
+        "description": "",
+        "owners": [person_dict(self.user.id)],
+        "frequency": "quarterly",
+        "task_groups": [{
+            "title": "tg_1",
+            "contact": person_dict(self.user.id),
+            "task_group_tasks": [{
+                "contact": person_dict(self.user.id),
+                "description": self.wf_generator.random_str(100),
+                "relative_start_day": 5,
+                "relative_start_month": 2,
+                "relative_end_day": 25,
+                "relative_end_month": 2,
+            },
+            ],
+        },
+        ]
+    }

--- a/src/tests/ggrc_workflows/notifications/test_monthly_wf.py
+++ b/src/tests/ggrc_workflows/notifications/test_monthly_wf.py
@@ -123,6 +123,7 @@ class TestMonthlyWorkflowNotification(TestCase):
 
     self.one_time_workflow_1 = {
         "title": "test monthly wf notifications",
+        "notify_on_change": True,
         "description": "some test workflow",
         "owners": [person_dict(self.person_2.id)],
         "frequency": "monthly",

--- a/src/tests/ggrc_workflows/notifications/test_one_time_wf.py
+++ b/src/tests/ggrc_workflows/notifications/test_one_time_wf.py
@@ -135,6 +135,7 @@ class TestOneTimeWorkflowNotification(TestCase):
     self.one_time_workflow_1 = {
         "title": "one time test workflow",
         "description": "some test workflow",
+        "notify_on_change": True,
         "owners": [person_dict(self.random_people[3].id)],
         "task_groups": [{
             "title": "one time task group",
@@ -177,6 +178,7 @@ class TestOneTimeWorkflowNotification(TestCase):
 
     self.one_time_workflow_single_person = {
         "title": "one time test workflow",
+        "notify_on_change": True,
         "description": "some test workflow",
         "owners": [person_dict(user)],
         "task_groups": [{

--- a/src/tests/ggrc_workflows/notifications/test_one_time_wf_decline_accept_tasks.py
+++ b/src/tests/ggrc_workflows/notifications/test_one_time_wf_decline_accept_tasks.py
@@ -253,6 +253,7 @@ class TestCycleTaskStatusChange(TestCase):
 
     self.one_time_workflow_1 = {
         "title": "one time test workflow",
+        "notify_on_change": True,
         "description": "some test workflow",
         "owners": [person_dict(self.user.id)],
         "task_groups": [{
@@ -270,6 +271,7 @@ class TestCycleTaskStatusChange(TestCase):
 
     self.one_time_workflow_2 = {
         "title": "one time test workflow",
+        "notify_on_change": True,
         "description": "some test workflow",
         "owners": [person_dict(self.user.id)],
         "task_groups": [{

--- a/src/tests/ggrc_workflows/notifications/test_one_time_wf_end_date_change.py
+++ b/src/tests/ggrc_workflows/notifications/test_one_time_wf_end_date_change.py
@@ -283,6 +283,7 @@ class TestOneTimeWfEndDateChange(TestCase):
 
     self.one_time_workflow_1 = {
         "title": "one time test workflow",
+        "notify_on_change": True,
         "description": "some test workflow",
         "owners": [person_dict(self.user.id)],
         "task_groups": [{

--- a/src/tests/ggrc_workflows/notifications/test_recurring_cycles.py
+++ b/src/tests/ggrc_workflows/notifications/test_recurring_cycles.py
@@ -99,6 +99,7 @@ class TestRecurringCycleNotifications(TestCase):
         "description": "",
         "owners": [person_dict(self.assignee.id)],
         "frequency": "quarterly",
+        "notify_on_change": True,
         "task_groups": [{
             "title": "tg_1",
             "contact": person_dict(self.assignee.id),


### PR DESCRIPTION
This will eventually add a test for the task bleed bug.

But I don't know how to fix this error:

```
ERROR: test_user_task_bleed     (test_enable_disable_notifications.TestEnableAndDisableNotifications)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/mock.py", line 1201, in     patched
    return func(*args, **keywargs)
  File "/vagrant/src/tests/ggrc_workflows/notifications/test_enable_disable_notifications.py", line 209, in test_user_task_bleed
    self.assertIn(user1.email, notif_data)
  File "/vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/sqlalchemy/orm/attributes.py", line 233, in __get__
    return self.impl.get(instance_state(instance), dict_)
  File "/vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/sqlalchemy/orm/attributes.py", line 579, in get
value = self.callable_(state, passive)
  File "/vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/sqlalchemy/orm/strategies.py", line 247, in _load_for_state
    (orm_util.state_str(state), self.key)
DetachedInstanceError: Parent instance <Person at 0x970ced0> is not bound to a Session; deferred load operation of attribute 'email' cannot proceed
```
