### PR TITLE
Fix karma tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,11 +19,10 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
+        'src/ggrc/assets/js_specs/spec_setup.js',
+        'src/ggrc/static/dashboard-templates.js',
         'src/ggrc/static/dashboard.js',
         'src/ggrc/static/dashboard-spec-helpers.js',
-        'src/ggrc/static/dashboard-templates.js',
-
-        'src/ggrc/assets/js_specs/spec_setup.js',
         'src/**/*_spec.js'
     ],
 

--- a/src/ggrc/assets/js_specs/spec_setup.js
+++ b/src/ggrc/assets/js_specs/spec_setup.js
@@ -5,7 +5,11 @@ Spec setup file.
 
 window.GGRC = window.GGRC || {};
 GGRC.current_user = GGRC.current_user || { id : 1, type : "Person" };
-
-// beforeEach(function() {
-//   spyOn($, "ajax").andReturn(new $.Deferred(function(dfd) { dfd.resolve({}); }));
-// });
+GGRC.permissions = {
+  create: {},
+  delete: {},
+  read: {},
+  update: {},
+  view_object_page: {},
+};
+GGRC.config = {};


### PR DESCRIPTION
Make sure spec_setup.js runs first and initializes the GGRC namespace
correctly. In the main app the GGRC namespace is preloaded in a haml
file.

Also make sure dashboard-templates.js is loaded before dashboard.js,
again mirroring the behavior of the main app.
