### PR TITLE
QUICK-FIX Fix comments notification styling

### DIFF
--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -66,39 +66,30 @@
         </div>
       </div>
 
-      <div class="row-fluid inner-hide">
-        <div class="span12 hidable">
+      <div class="row-fluid wrap-row">
+        <div class="span12">
           <div class="comment-notification">
             <label>
-              <input type="checkbox" 
-                     name="send_by_default"
-                     {{# send_by_default}}checked{{/send_by_default}}>
               Enable notifications on comments
             </label>
             <ul class="comment-notification__list">
               <li>
-								<label class="input--inline">
-                  <input type="checkbox" 
-                        name="Creator"
-                        {{# Creator}}checked{{/Creator}}>
+                <label class="input--inline">
+                  <input type="checkbox" name="Creator" {{# Creator}}checked{{/Creator}}>
                   Notify creator(s)
-								</label>
+                </label>
               </li>
               <li>
-								<label class="input--inline">
-                  <input type="checkbox" 
-                        name="Assessor"
-                        {{# Assessor}}checked{{/Assessor}}>
+                <label class="input--inline">
+                  <input type="checkbox" name="Assessor" {{# Assessor}}checked{{/Assessor}}>
                   Notify assessor(s)
-								</label>
+                </label>
               </li>
               <li>
-								<label class="input--inline">
-                  <input type="checkbox" 
-                        name="Verifier"
-                        {{# Verifier}}checked{{/Verifier}}>
+                <label class="input--inline">
+                  <input type="checkbox" name="Verifier" {{# Verifier}}checked{{/Verifier}}>
                   Notify verifier(s)
-								</label>
+                </label>
               </li>
             </ul>
           </div>

--- a/src/ggrc/assets/stylesheets/modules/_comment-notification.scss
+++ b/src/ggrc/assets/stylesheets/modules/_comment-notification.scss
@@ -6,7 +6,6 @@
  */
 
 .comment-notification {
-  margin-bottom: 20px;
   &__list {
     @extend %reset-list;
   }


### PR DESCRIPTION
@zidarsk8 There are 3 things that I need to mention:
1) If no checkboxes are checked then system will send emails to all by default. If this is true, then we don't need checkbox on `Enable notifications on comments`. It can be label like everything else.
2) I see that comment notifications exist only for Assessments. Initial request was to have it on Assessments, Requests and cycle Tasks. If this is changed then everything is ok, but if isn't, then we are missing notifications on Requests and cycle Tasks.
3) Since I've removed checkbox from `Enable notifications on comments` label, please adjust your code and remove redundant stuff for this.

Let me know if you have any questions.
