### PR TITLE
QUICK-FIX Fix creation of asmts from asmt templates in Selenium tests

### DIFF
--- a/src/requirements-selenium.txt
+++ b/src/requirements-selenium.txt
@@ -13,6 +13,7 @@ pytest==3.2.1
 requests==2.18.3
 selenium==3.4.1
 sniffer==0.3.5
+inflection==0.3.1
 timeout-decorator==0.3.3
 pytest-timeout==1.2.0
 pytest-pycharm==0.4.0

--- a/test/selenium/src/lib/constants/objects.py
+++ b/test/selenium/src/lib/constants/objects.py
@@ -4,6 +4,8 @@
 
 import sys
 
+import inflection
+
 
 # objects
 PROGRAMS = "programs"
@@ -106,7 +108,7 @@ def get_singular(plural, title=False):
  """
   _singular = _get_singular([plural])[0]
   if title:
-    _singular = _singular.title()
+    _singular = inflection.camelize(_singular.lower())
   else:
     _singular = _singular.lower()
   return _singular

--- a/test/selenium/src/lib/service/rest/template_provider.py
+++ b/test/selenium/src/lib/service/rest/template_provider.py
@@ -8,6 +8,8 @@
 import json
 import os
 
+import inflection
+
 
 class TemplateProvider(object):
   """Provider of methods for work with JSON templates."""
@@ -18,7 +20,7 @@ class TemplateProvider(object):
     (items (kwargs): key=value).
     Return dictionary like as {type: {key: value, ...}}.
     """
-    json_tmpl_name = json_tmpl_name.lower()
+    json_tmpl_name = inflection.underscore(json_tmpl_name)
     path = os.path.join(
         os.path.dirname(__file__), "template/{0}.json".format(json_tmpl_name))
     with open(path) as json_file:


### PR DESCRIPTION
This should fix setting type of assessment template.
It should be "AssessmentTemplate" rather than "Assessment_Template".
Lower case usage should still be "assessment_template".

@SergeyRabtsau please review